### PR TITLE
Force usage of Theano's image ordering.

### DIFF
--- a/train_steering_model.py
+++ b/train_steering_model.py
@@ -8,6 +8,7 @@ import json
 from keras.models import Sequential
 from keras.layers import Dense, Dropout, Flatten, Lambda, ELU
 from keras.layers.convolutional import Convolution2D
+from keras import backend as K
 
 from server import client_generator
 
@@ -47,6 +48,8 @@ def get_model(time_len=1):
 
 
 if __name__ == "__main__":
+  K.set_image_dim_ordering('th')
+
   parser = argparse.ArgumentParser(description='Steering angle model trainer')
   parser.add_argument('--host', type=str, default="localhost", help='Data server ip address.')
   parser.add_argument('--port', type=int, default=5557, help='Port of server.')


### PR DESCRIPTION
- The method `get_model()` in `train_steering_model.py` provides the
input image to the `Lambda` layer as a shape (ch, row, col). This is in
the Theano image dimension format, instead of Tensorflow's, which is
(row, col, ch).

- An alternative to this is to modify the `keras.json` file in the Keras
installation path (usually located in `~/.keras/keras.json`), in the
`image_dim_ordering` row.